### PR TITLE
Add CipherBytesFromPrimitives func

### DIFF
--- a/crypt/encrypt.go
+++ b/crypt/encrypt.go
@@ -78,13 +78,19 @@ func CipherText(plaintext []byte, filepath string, singleLine bool) (err error) 
 
 //CipherBytes encrypts plaintext bytes and returns ciphertext bytes
 func CipherBytes(plaintext []byte, singleLine bool) (cipherBytes []byte) {
+	return CipherBytesFromPrimitives(plaintext, singleLine, defaultOptions.ProjectID,
+		defaultOptions.LocationID, defaultOptions.KeyRingID,
+		defaultOptions.CryptoKeyID, defaultOptions.KeyName)
+}
+
+func CipherBytesFromPrimitives(plaintext []byte, singleLine bool, projectID,
+	locationID, keyRingID, cryptoKeyID, keyName string) (cipherBytes []byte) {
 	dekSize := 32
 	dek := randByteSlice(dekSize)
 	nonce := randByteSlice(nonceLength)
 	encrypt := true
-	encryptedDek := googleKMSCrypto(dek, defaultOptions.ProjectID,
-		defaultOptions.LocationID, defaultOptions.KeyRingID,
-		defaultOptions.CryptoKeyID, defaultOptions.KeyName, encrypt)
+	encryptedDek := googleKMSCrypto(dek, projectID, locationID, keyRingID,
+		cryptoKeyID, keyName, encrypt)
 	cipherBytes = []byte(base64.StdEncoding.EncodeToString(append(
 		append(cipherText(plaintext, cipherblock(dek), nonce, encrypt),
 			nonce...),

--- a/crypt/encrypt.go
+++ b/crypt/encrypt.go
@@ -76,13 +76,15 @@ func CipherText(plaintext []byte, filepath string, singleLine bool) (err error) 
 	return
 }
 
-//CipherBytes encrypts plaintext bytes and returns ciphertext bytes
+//CipherBytes uses 'defaultOptions' go-flags to encrypt plaintext bytes and
+//return ciphertext bytes
 func CipherBytes(plaintext []byte, singleLine bool) (cipherBytes []byte) {
 	return CipherBytesFromPrimitives(plaintext, singleLine, defaultOptions.ProjectID,
 		defaultOptions.LocationID, defaultOptions.KeyRingID,
 		defaultOptions.CryptoKeyID, defaultOptions.KeyName)
 }
 
+//CipherBytesFromPrimitives encrypts plaintext bytes and returns ciphertext bytes
 func CipherBytesFromPrimitives(plaintext []byte, singleLine bool, projectID,
 	locationID, keyRingID, cryptoKeyID, keyName string) (cipherBytes []byte) {
 	dekSize := 32


### PR DESCRIPTION
This is required so that users of Mantle as a Golang dependency can use the encryption functionality without having to use the  'defaultOptions' go-flags (which are only used on command line)