### PR TITLE
Pass full ciphertext byte slice to checking func rather than subset

### DIFF
--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -43,9 +43,9 @@ var defaultOptions = Defaults{}
 //Parser is a new Parser with default options
 var Parser = flags.NewParser(&defaultOptions, flags.Default)
 
-var nonceLength = 12
-var dekLength = 32
-var encDekLength = 113
+const nonceLength = 12
+const dekLength = 32
+const encDekLength = 113
 
 //check panics if error is not nil
 func check(e error) {

--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -44,6 +44,8 @@ var defaultOptions = Defaults{}
 var Parser = flags.NewParser(&defaultOptions, flags.Default)
 
 var nonceLength = 12
+var dekLength = 32
+var encDekLength = 113
 
 //check panics if error is not nil
 func check(e error) {

--- a/crypt/decrypt_test.go
+++ b/crypt/decrypt_test.go
@@ -26,7 +26,8 @@ func TestMinimumCipherTextLength(t *testing.T) {
 	}()
 
 	plaintext := []byte("I'm Very Short")
+	filepath := "./plain.txt"
 
-	checkCipherTextLength(plaintext)
+	checkCipherTextLength(plaintext, filepath)
 
 }

--- a/crypt/encrypt.go
+++ b/crypt/encrypt.go
@@ -87,8 +87,7 @@ func CipherBytes(plaintext []byte, singleLine bool) (cipherBytes []byte) {
 //CipherBytesFromPrimitives encrypts plaintext bytes and returns ciphertext bytes
 func CipherBytesFromPrimitives(plaintext []byte, singleLine bool, projectID,
 	locationID, keyRingID, cryptoKeyID, keyName string) (cipherBytes []byte) {
-	dekSize := 32
-	dek := randByteSlice(dekSize)
+	dek := randByteSlice(dekLength)
 	nonce := randByteSlice(nonceLength)
 	encrypt := true
 	encryptedDek := googleKMSCrypto(dek, projectID, locationID, keyRingID,


### PR DESCRIPTION
Variablize dekLength and encDekLength

Add more helpful text to the ciphertext length panic

fixes #40 