### PR TITLE
On decrypt pass project/location/key/keyring basic types

### DIFF
--- a/crypt/decrypt.go
+++ b/crypt/decrypt.go
@@ -98,14 +98,22 @@ func PlainText(filepath string) (plaintext []byte, err error) {
 // PlainTextFromBytes returns a slice of bytes (the plaintext), decrypted from
 // a byte slice
 func PlainTextFromBytes(cipherBytes []byte) (plaintext []byte, err error) {
+	return PlainTextFromPrimitives(cipherBytes, defaultOptions.ProjectID,
+		defaultOptions.LocationID, defaultOptions.KeyRingID,
+		defaultOptions.CryptoKeyID, defaultOptions.KeyName)
+}
+
+// PlainTextFromPrimitives returns a slice of bytes (the plaintext), decrypted from
+// a byte slice
+func PlainTextFromPrimitives(cipherBytes []byte, projectID, locationID, keyRingID,
+	cryptoKeyID, keyName string) (plaintext []byte, err error) {
 	checkCipherTextLength(cipherBytes)
 	cipherLength := len(cipherBytes)
 	encrypt := false
 	encryptedDek := cipherBytes[cipherLength-encDekLength : cipherLength]
 	nonce := cipherBytes[cipherLength-(encDekLength+nonceLength) : cipherLength-encDekLength]
-	decryptedDek := googleKMSCrypto(encryptedDek, defaultOptions.ProjectID,
-		defaultOptions.LocationID, defaultOptions.KeyRingID,
-		defaultOptions.CryptoKeyID, defaultOptions.KeyName, encrypt)
+	decryptedDek := googleKMSCrypto(encryptedDek, projectID,
+		locationID, keyRingID, cryptoKeyID, keyName, encrypt)
 	plaintext = cipherText(cipherBytes[0:len(cipherBytes)-(encDekLength+nonceLength)],
 		cipherblock(decryptedDek), nonce, encrypt)
 	return

--- a/crypt/encrypt.go
+++ b/crypt/encrypt.go
@@ -105,7 +105,8 @@ func CipherBytesFromPrimitives(plaintext []byte, singleLine, disableValidation b
 		fmt.Println("Validating ciphertext")
 		cipherString, err := base64.StdEncoding.DecodeString(string(cipherBytes))
 		check(err)
-		_, err = PlainTextFromBytes(cipherString)
+		_, err = PlainTextFromPrimitives(cipherString, projectID,
+			locationID, keyRingID, cryptoKeyID, keyName)
 		check(err)
 	}
 	return


### PR DESCRIPTION
Encryption using Mantle as a dependency (as opposed to CLI) was failing as `defaultOptions` (whose fields are populated when using the CLI) was returning zero values for strings, which was leading to failed validation.

This change adds a PlainTextFromPrimitives() func to `decrypt.go` which allows `encrypt.go` to call it with primitive/basic types.