### PR TITLE
Export provider kms types

### DIFF
--- a/crypt/aws.go
+++ b/crypt/aws.go
@@ -20,14 +20,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 )
 
-type awsKms struct{}
+// AwsKms type
+type AwsKms struct{}
 
-func (a awsKms) encryptedDekLength() int {
+func (a AwsKms) encryptedDekLength() int {
 	return 185
 }
 
 // uses aws kms to either encrypt or decrypt a byte slice
-func (a awsKms) crypto(payload []byte, projectid, locationid, keyringid,
+func (a AwsKms) crypto(payload []byte, projectid, locationid, keyringid,
 	cryptokeyid, keyname string, encrypt bool) (resultText []byte, err error) {
 
 	svc := kms.New(session.New(&aws.Config{

--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -48,8 +48,8 @@ var (
 	//Parser is a new Parser with default options
 	Parser       = flags.NewParser(&defaultOptions, flags.Default)
 	kmsProviders = map[string]KmsProvider{
-		"AWS": awsKms{},
-		"GCP": gcpKms{},
+		"AWS": AwsKms{},
+		"GCP": GcpKms{},
 	}
 )
 
@@ -60,7 +60,7 @@ const (
 
 func getKmsProvider(provider string) (kmsProvider KmsProvider, err error) {
 	if provider == "" {
-		return gcpKms{}, nil
+		return GcpKms{}, nil
 	}
 	kmsProvider, ok := kmsProviders[strings.ToUpper(provider)]
 	if !ok {

--- a/crypt/gcp.go
+++ b/crypt/gcp.go
@@ -9,14 +9,15 @@ import (
 	cloudkms "google.golang.org/api/cloudkms/v1"
 )
 
-type gcpKms struct{}
+// GcpKms type
+type GcpKms struct{}
 
-func (g gcpKms) encryptedDekLength() int {
+func (g GcpKms) encryptedDekLength() int {
 	return 114
 }
 
 // uses google kms to either encrypt or decrypt a byte slice
-func (g gcpKms) crypto(payload []byte, projectid, locationid, keyringid,
+func (g GcpKms) crypto(payload []byte, projectid, locationid, keyringid,
 	cryptokeyid, keyname string, encrypt bool) (resultText []byte, err error) {
 	kmsService := kmsClient()
 	var parentName string


### PR DESCRIPTION
Required by users of `mantle` as a dependency, who'll call the `CipherBytesFromPrimitives()` function